### PR TITLE
Upgrade to rpmalloc 1.4.1

### DIFF
--- a/rpmalloc-sys/Cargo.toml
+++ b/rpmalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpmalloc-sys"
-version = "0.2.0+c4d2c05"
+version = "0.2.1+1.4.1"
 description = "Unsafe FFI bindings to rpmalloc C library"
 authors = ["Embark <opensource@embark-studios.com>", "Johan Andersson <repi@repi.se>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This upgrade to use the rpmalloc 1.4.1 proper release instead of a mid-development commit.

Changes: https://github.com/mjansson/rpmalloc/releases/tag/1.4.1

No changes in the Rust crates so just a patch version for `rpmalloc-sys`.

Fix #9 