### PR TITLE
rpmalloc-sys: Update `rpmalloc` submodule to latest upstream branch

### DIFF
--- a/rpmalloc-sys/build.rs
+++ b/rpmalloc-sys/build.rs
@@ -11,7 +11,9 @@ fn main() {
     }
 
     let mut build = cc::Build::new();
-    let mut build = build.file(path.join("rpmalloc.c")).opt_level(2);
+    let c_file = path.join("rpmalloc.c");
+    println!("cargo:rerun-if-changed={}", c_file.display());
+    let mut build = build.file(c_file).opt_level(2);
     // add defines for enabled features
 
     #[rustfmt::skip]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This submodule was originally pointing to a commit somewhere between the 1.4.3 and 1.4.4 release (at the time this Rust wrapper was last committed to).  Note that the upstream `main` branch is slightly ahead of the latest 1.4.5 release, because it also includes a just-merged fix for using Android API level 29+ compiled with LLVM 17+, which Rust apps would otherwise fail to load at runtime.  The 1.4.5 release already contains a fix for ARM64 Windows, which is equally of interest to us.

Finally, also add a `rerun-if-changed` on the `rpmalloc.c` file, so that **local** submodule changes and experimentations actually cause the crate to be recompiled.  `cc-rs` only emits these for the environment variables, but not for `.file()` arguments.
